### PR TITLE
Fix regex escaping

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -98,7 +98,7 @@ html_static_path = ["_static"]
 # html_sidebars = {}
 
 # CopyButton configuration
-copybutton_prompt_text = r">>> |\$ |\[\d*\]: |In \[\d*\]: |\.\.\.: "
+copybutton_prompt_text = r">>> |\$ |\[\d*\]: |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
 copybutton_prompt_is_regexp = True
 # Switches for testing but shouldn't be activated in the live docs
 # copybutton_only_copy_prompt_lines = False

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -98,7 +98,7 @@ html_static_path = ["_static"]
 # html_sidebars = {}
 
 # CopyButton configuration
-copybutton_prompt_text = ">>> |\\\\$ |\\[\\d*\\]: |\\.\\.\\.: "
+copybutton_prompt_text = r">>> |\$ |\[\d*\]: |In \[\d*\]: |\.\.\.: "
 copybutton_prompt_is_regexp = True
 # Switches for testing but shouldn't be activated in the live docs
 # copybutton_only_copy_prompt_lines = False

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -140,14 +140,31 @@ Using regexp prompt identifiers
 
 If your prompts are more complex than a single string, then you can use a regexp to match with.
 
+.. note::
+
+   Keep in mind that the
+   `RegExp <https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp>`_
+   you are writing is
+   `evaluated in JavaScript <https://github.com/executablebooks/sphinx-copybutton/blob/a58da090dae6f4d38870929e0258a0c8ee626f8f/sphinx_copybutton/_static/copybutton_funcs.js#L7>`_
+   and not in Python.
+   In some edge cases this might lead to different results.
+
+If you enclose your regexp in a raw string (``r""``),
+you can easily test that your RegExp matches all the wanted prompts,
+i.e. at `RegEx101 <https://regex101.com>`_.
+
+For example this documentation uses the following configuration:
+
 .. code-block:: python
 
-   copybutton_prompt_text = "\\[\\d*\\]: |\\.\\.\\.: "
+   copybutton_prompt_text = r">>> |\$ |\[\d*\]: |In \[\d*\]: |\.\.\.: "
    copybutton_prompt_is_regexp = True
 
-For example when using ipython prompts with continuations:
+Which also matches the prompts when using ipython prompts with continuations:
 
 .. code-block:: restructuredtext
+
+   Old style:
 
    .. code-block:: ipython
 
@@ -156,12 +173,32 @@ For example when using ipython prompts with continuations:
       output
       [2]: second
 
+   New style:
+
+   .. code-block:: ipython
+
+      In [1]: first
+      ...: continuation
+      output
+      In [2]: second
+
+Old style:
+
 .. code-block:: ipython
 
    [1]: first
    ...: continuation
    output
    [2]: second
+
+New style:
+
+.. code-block:: ipython
+
+   In [1]: first
+   ...: continuation
+   output
+   In [2]: second
 
 Configure whether *only* lines with prompts are copied
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -157,48 +157,49 @@ For example this documentation uses the following configuration:
 
 .. code-block:: python
 
-   copybutton_prompt_text = r">>> |\$ |\[\d*\]: |In \[\d*\]: |\.\.\.: "
+   copybutton_prompt_text = r">>> |\$ |\[\d*\]: |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
    copybutton_prompt_is_regexp = True
 
-Which also matches the prompts when using ipython prompts with continuations:
+Which also matches the prompts when using prompts with continuations:
 
 .. code-block:: restructuredtext
 
-   Old style:
-
-   .. code-block:: ipython
-
-      [1]: first
-      ...: continuation
-      output
-      [2]: second
-
-   New style:
+   ``ipython`` and ``qtconsole`` style:
 
    .. code-block:: ipython
 
       In [1]: first
-      ...: continuation
+         ...: continuation
       output
       In [2]: second
 
-Old style:
+   ``jupyter`` style:
 
-.. code-block:: ipython
+   .. code-block:: ipython
 
-   [1]: first
-   ...: continuation
-   output
-   [2]: second
+      In [1]: first
+            : continuation
+      output
+      In [2]: second
 
-New style:
+``ipython`` and ``qtconsole`` style:
 
 .. code-block:: ipython
 
    In [1]: first
-   ...: continuation
+      ...: continuation
    output
    In [2]: second
+
+``jupyter`` style:
+
+.. code-block:: ipython
+
+   In [1]: first
+         : continuation
+   output
+   In [2]: second
+
 
 Configure whether *only* lines with prompts are copied
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/sphinx_copybutton/_static/copybutton.js_t
+++ b/sphinx_copybutton/_static/copybutton.js_t
@@ -86,7 +86,7 @@ const addCopyButtonToCodeCells = () => {
 
 var copyTargetText = (trigger) => {
   var target = document.querySelector(trigger.attributes['data-clipboard-target'].value);
-  return formatCopyText(target.innerText, '{{ copybutton_prompt_text }}', {{ copybutton_prompt_is_regexp | lower }}, {{ copybutton_only_copy_prompt_lines | lower }},  {{ copybutton_remove_prompts | lower }})
+  return formatCopyText(target.innerText, {{ "{!r}".format(copybutton_prompt_text) }}, {{ copybutton_prompt_is_regexp | lower }}, {{ copybutton_only_copy_prompt_lines | lower }},  {{ copybutton_remove_prompts | lower }})
 }
 
   // Initialize with a callback so we can modify the text before copy

--- a/sphinx_copybutton/_static/test.js
+++ b/sphinx_copybutton/_static/test.js
@@ -105,38 +105,6 @@ $ second`,
 		expected: 'first\nsecond'
 	},
 	{
-	/* false positive regex test see:
-	https://github.com/executablebooks/sphinx-copybutton/issues/86
-	*/
-		description: 'with ipython prompt regexp (false positive)',
-		text: `
-[1]: first
-...: continuation
-output
-[2]: second`,
-		prompt: '[\d*]: |\.\.\.: ',
-		isRegexp: true,
-		onlyCopyPromptLines: true,
-		removePrompts: true,
-		expected: 'first\ncontinuation\nsecond'
-	},
-	{
-		description: 'with ipython prompt regexp, keep prompts (false positive)',
-		text: `
-[1]: first
-...: continuation
-output
-[2]: second`,
-		prompt: '[\d*]: |\.\.\.: ',
-		isRegexp: true,
-		onlyCopyPromptLines: true,
-		removePrompts: false,
-		expected: '[1]: first\n...: continuation\n[2]: second'
-	},
-	{
-	/* proper regex test see:
-	https://github.com/executablebooks/sphinx-copybutton/issues/86
-	*/
 		description: 'with ipython prompt (old and new style) regexp',
 		text: `
 [1]: first
@@ -163,6 +131,23 @@ In [3]: jupyter`,
 		onlyCopyPromptLines: true,
 		removePrompts: false,
 		expected: '[1]: first\n...: continuation\n[2]: second\nIn [3]: jupyter',
+	},
+	{
+	/* The following is included to demonstrate an example of a false positive regex test.
+	As noted in https://github.com/executablebooks/sphinx-copybutton/issues/86,
+	JS RegEx in some cases "fixes" incorrect regexes rather than failing on them.
+	*/
+		description: 'with ipython prompt regexp (false positive)',
+		text: `
+[1]: first
+...: continuation
+output
+[2]: second`,
+		prompt: '[\d*]: |\.\.\.: ',
+		isRegexp: true,
+		onlyCopyPromptLines: true,
+		removePrompts: true,
+		expected: 'first\ncontinuation\nsecond'
 	}
 ]
 

--- a/sphinx_copybutton/_static/test.js
+++ b/sphinx_copybutton/_static/test.js
@@ -105,7 +105,10 @@ $ second`,
 		expected: 'first\nsecond'
 	},
 	{
-		description: 'with ipython prompt regexp',
+	/* false positive regex test see:
+	https://github.com/executablebooks/sphinx-copybutton/issues/86
+	*/
+		description: 'with ipython prompt regexp (false positive)',
 		text: `
 [1]: first
 ...: continuation
@@ -118,7 +121,7 @@ output
 		expected: 'first\ncontinuation\nsecond'
 	},
 	{
-		description: 'with ipython prompt regexp, keep prompts',
+		description: 'with ipython prompt regexp, keep prompts (false positive)',
 		text: `
 [1]: first
 ...: continuation
@@ -129,6 +132,37 @@ output
 		onlyCopyPromptLines: true,
 		removePrompts: false,
 		expected: '[1]: first\n...: continuation\n[2]: second'
+	},
+	{
+	/* proper regex test see:
+	https://github.com/executablebooks/sphinx-copybutton/issues/86
+	*/
+		description: 'with ipython prompt (old and new style) regexp',
+		text: `
+[1]: first
+...: continuation
+output
+[2]: second
+In [3]: jupyter`,
+		prompt: '\\[\\d*\\]: |In \\[\\d*\\]: |\\.\\.\\.: ',
+		isRegexp: true,
+		onlyCopyPromptLines: true,
+		removePrompts: true,
+		expected: 'first\ncontinuation\nsecond\njupyter',
+	},
+	{
+		description: 'with ipython prompt (old and new style) regexp, keep prompts',
+		text: `
+[1]: first
+...: continuation
+output
+[2]: second
+In [3]: jupyter`,
+		prompt: '\\[\\d*\\]: |In \\[\\d*\\]: |\\.\\.\\.: ',
+		isRegexp: true,
+		onlyCopyPromptLines: true,
+		removePrompts: false,
+		expected: '[1]: first\n...: continuation\n[2]: second\nIn [3]: jupyter',
 	}
 ]
 


### PR DESCRIPTION
As concluded in #86, this fixes the way that `copybutton_prompt_text` is injected into `copybutton.js_t`.
And updates the docs on how to use the regex feature.
I left the old tests in there, since I kind like those oddities if you know them. But if that is too much clutter for you I can remove them.

Not sure how much you value [SemVer](https://semver.org/) but this is a breaking change, since it will break functionality for people that already use the regex feature. 

fixes #86 

**Note**: I left #84 ([besides](https://github.com/executablebooks/sphinx-copybutton/issues/84#issuecomment-645670875)) untouched, since IMHO this should configurable i.e. by a variable `copy_blank_lines`.  I just can see someone complaining around the corner, even so 'copy as is' is the most natural thing and should be default 😒 