### PR TITLE
📖 DOC: Add conda-forge badge and install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sphinx-copybutton
 
-[![PyPI](https://img.shields.io/pypi/v/sphinx-copybutton.svg)](https://pypi.org/project/sphinx_copybutton/) | [![Documentation](https://readthedocs.org/projects/sphinx-copybutton/badge/?version=latest)](https://sphinx-copybutton.readthedocs.io/en/latest/?badge=latest)
+[![PyPI](https://img.shields.io/pypi/v/sphinx-copybutton.svg)](https://pypi.org/project/sphinx_copybutton/) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/sphinx-copybutton.svg)](https://anaconda.org/conda-forge/sphinx-copybutton) | [![Documentation](https://readthedocs.org/projects/sphinx-copybutton/badge/?version=latest)](https://sphinx-copybutton.readthedocs.io/en/latest/?badge=latest)
 
 A small sphinx extension to add a "copy" button to code blocks.
 
@@ -12,16 +12,23 @@ See [the sphinx-copybutton documentation](https://sphinx-copybutton.readthedocs.
 
 You can install `sphinx-copybutton` with `pip`:
 
-```
+```bash
 pip install sphinx-copybutton
 ```
+
+Or with `conda` via `conda-forge`:
+
+```bash
+conda install -c conda-forge sphinx-copybutton
+```
+
 
 ## Usage
 
 In your `conf.py` configuration file, add `sphinx_copybutton` to your extensions list.
 E.g.:
 
-```
+```python
 extensions = [
     ...
     'sphinx_copybutton'

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,6 +10,10 @@ Sphinx-copybutton
    :target: https://pypi.org/project/sphinx_copybutton
    :alt: PyPi page
 
+.. image:: https://img.shields.io/conda/vn/conda-forge/sphinx-copybutton.svg
+   :target: https://anaconda.org/conda-forge/sphinx-copybutton
+   :alt: Conda Version
+
 Sphinx-copybutton does one thing: add a little "copy" button to the right
 of your code blocks. That's it! It is a lightweight wrapper around the
 excellent (and also lightweight) Javascript library
@@ -63,6 +67,12 @@ You can install ``sphinx-copybutton`` with ``pip``:
 .. code-block:: bash
 
    pip install sphinx-copybutton
+
+Or with ``conda`` via ``conda-forge``:
+
+.. code-block:: bash
+
+   conda install -c conda-forge sphinx-copybutton
 
 `Here's a link to the sphinx-copybutton GitHub repository <https://github.com/ExecutableBookProject/sphinx-copybutton>`_.
 


### PR DESCRIPTION
Since `sphinx-copybutton` [is also available via conda-forge](https://anaconda.org/conda-forge/sphinx-copybutton), it should be mentioned in the docs. And as a bonus this adds a pretty badge 😋 