### PR TITLE
🐛 FIX: Fix button position

### DIFF
--- a/sphinx_copybutton/_static/copybutton.css
+++ b/sphinx_copybutton/_static/copybutton.css
@@ -19,7 +19,7 @@ a.copybtn > img {
     vertical-align: top;
     margin: 0;
     top: 0;
-    left: 0;
+    right: 0;
     position: absolute;
 }
 


### PR DESCRIPTION
before:
![grafik](https://user-images.githubusercontent.com/2836374/99309883-716bf400-285a-11eb-9fed-6ab73bbc3ecc.png)

after: 
![grafik](https://user-images.githubusercontent.com/2836374/99309963-8fd1ef80-285a-11eb-87fd-be34feb9a258.png)

This became apparent due to the new button image #98. For the old button image, the CSS worked by chance (`a.copybutton.width = 1em` is as wide as the old image was.).