### PR TITLE
🔧 MAINT: Fix GitHub link to new organization name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     long_description=readme_text,
     long_description_content_type="text/markdown",
     author="Executable Book Project",
-    url="https://github.com/ExecutableBookProject/sphinx-copybutton",
+    url="https://github.com/executablebooks/sphinx-copybutton",
     license="MIT License",
     packages=find_packages(),
     package_data={


### PR DESCRIPTION
- This change is obvious from the diff.
- GitHub organization has changed, update setup.py