### PR TITLE
🔧 MAINT: fix pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,8 @@ exclude: >
 
 repos:
 
-  - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.3
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
     hooks:
     - id: check-json
     - id: check-yaml
@@ -18,6 +18,6 @@ repos:
     - id: flake8
 
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 21.5b1
     hooks:
     - id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,10 @@ repos:
     - id: check-yaml
     - id: end-of-file-fixer
     - id: trailing-whitespace
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 3.9.2
+    hooks:
     - id: flake8
 
   - repo: https://github.com/psf/black

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,6 @@ setup(
     classifiers=["License :: OSI Approved :: MIT License"],
     install_requires=["sphinx>=1.8"],
     extras_require={
-        "code_style": ["flake8<3.8.0,>=3.7.0", "black", "pre-commit==2.12.1"],
+        "code_style": ["pre-commit==2.12.1"],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,6 @@ setup(
     classifiers=["License :: OSI Approved :: MIT License"],
     install_requires=["sphinx>=1.8"],
     extras_require={
-        "code_style": ["flake8<3.8.0,>=3.7.0", "black", "pre-commit==1.17.0"],
+        "code_style": ["flake8<3.8.0,>=3.7.0", "black", "pre-commit==2.12.1"],
     },
 )


### PR DESCRIPTION
The CI is failing, for [example](https://github.com/executablebooks/sphinx-copybutton/pull/122/checks?check_run_id=2558493872):

> Error:  The hook `black` requires pre-commit version 2.9.2 but version 1.17.0 is installed.  Perhaps run `pip install --upgrade pre-commit`.

The first commit here updates the pre-commit pin to the latest 2.12.1. (Perhaps even unpin this?)

---

Next, when running pre-commit, it warns:

> [WARNING] The 'rev' field of repo 'https://github.com/psf/black' appears to be a mutable reference (moving tag / branch).  Mutable references are never updated after first install and are not supported.  See https://pre-commit.com/#using-the-latest-version-for-a-repository for more details.  Hint: `pre-commit autoupdate` often fixes this.

The second commit runs `pre-commit autoupdate` to update both Black and pre-commit-hooks.

---

Next, pre-commit-hooks errors due to the Flake8 hook having been moved:

```
Check JSON...........................................(no files to check)Skipped
Check Yaml...............................................................Passed
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Passed
Flake8 (removed).........................................................Failed
- hook id: flake8
- exit code: 1

`flake8` has been removed -- use `flake8` from https://gitlab.com/pycqa/flake8

black................................................(no files to check)Skipped
```

The third commit updates the hooks so it uses Flake8 from its new home at https://github.com/PyCQA/flake8.

---

Finally, 4th commit: we don't need to explicitly install Black and Flake8 into the environment for them to be used by pre-commit. In fact, it's unnecessary because pre-commit manages its own dependencies.
