### PR TITLE
🔧 MAINT: Update Python versions in metadata and tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
     - name: Install dependencies
@@ -35,7 +35,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
@@ -48,12 +48,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -78,7 +78,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v2
       - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: 3.7
       - name: Build package
@@ -87,7 +87,7 @@ jobs:
           git submodule update --init
           python setup.py sdist bdist_wheel
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@v1.1.0
+        uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           user: __token__
           password: ${{ secrets.PYPI_KEY }}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Configuration file for the Sphinx documentation builder.
 #

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -60,7 +60,7 @@ Installation
 
 .. note::
 
-   ``sphinx-copybutton`` only works on Python >= 3.4
+   ``sphinx-copybutton`` only works on Python >= 3.6
 
 You can install ``sphinx-copybutton`` with ``pip``:
 

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,6 @@ setup(
     python_requires=">=3.6",
     install_requires=["sphinx>=1.8"],
     extras_require={
-        "code_style": ["flake8<3.8.0,>=3.7.0", "black", "pre-commit==1.17.0"],
+        "code_style": ["flake8<3.8.0,>=3.7.0", "black", "pre-commit~=2.9.2"],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ if os.path.isdir("clipboard.js") and not os.path.isfile(
         """
     )
 
-with open("./README.md", "r") as ff:
+with open("./README.md") as ff:
     readme_text = ff.read()
 
 # Parse version

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         ]
     },
     classifiers=["License :: OSI Approved :: MIT License"],
+    python_requires=">=3.6",
     install_requires=["sphinx>=1.8"],
     extras_require={
         "code_style": ["flake8<3.8.0,>=3.7.0", "black", "pre-commit==1.17.0"],

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,15 @@ setup(
             "_static/clipboard.min.js",
         ]
     },
-    classifiers=["License :: OSI Approved :: MIT License"],
+    classifiers=[
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3 :: Only",
+    ],
     python_requires=">=3.6",
     install_requires=["sphinx>=1.8"],
     extras_require={


### PR DESCRIPTION
* Update docs to reflect 3.6+ is supported
* Test CI with Python 3.9 and bump actions versions
* Add `python_requires` to help pip install the right version for the user
* Add Trove classifier metadata for the Python versions for display on PyPI
* Upgrade Python syntax with https://github.com/asottile/pyupgrade (this also has a pre-commit hook available)