### PR TITLE
👌 IMPROVE: Allow copying empty lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,5 @@ _build/
 node_modules/
 
 .DS_Store
+
+.idea

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -268,6 +268,20 @@ strip the prompts), use the following configuration in ``conf.py``:
 
     copybutton_remove_prompts = False
 
+Configure whether *empty* lines are copied
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, sphinx-copybutton does not copy empty lines.
+
+To enable copying empty lines, use the following configuration in ``conf.py``:
+
+.. code-block:: python
+
+    copybutton_copy_empty_lines = True
+
+In this case, all empty lines (determined by ``line.strip() === ""``) will be
+passed through.
+
 Use a different copy button image
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -271,16 +271,14 @@ strip the prompts), use the following configuration in ``conf.py``:
 Configure whether *empty* lines are copied
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, sphinx-copybutton does not copy empty lines.
+By default, sphinx-copybutton will also copy / pass through empty lines,
+determined by ``line.trim() === ''``.
 
-To enable copying empty lines, use the following configuration in ``conf.py``:
+To disable copying empty lines, use the following configuration in ``conf.py``:
 
 .. code-block:: python
 
-    copybutton_copy_empty_lines = True
-
-In this case, all empty lines (determined by ``line.strip() === ""``) will be
-passed through.
+    copybutton_copy_empty_lines = False
 
 Use a different copy button image
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/sphinx_copybutton/__init__.py
+++ b/sphinx_copybutton/__init__.py
@@ -27,6 +27,9 @@ def add_to_context(app, config):
     config.html_context.update(
         {"copybutton_remove_prompts": config.copybutton_remove_prompts}
     )
+    config.html_context.update(
+        {"copybutton_copy_empty_lines": config.copybutton_copy_empty_lines}
+    )
     config.html_context.update({"copybutton_image_path": config.copybutton_image_path})
     config.html_context.update({"copybutton_selector": config.copybutton_selector})
     config.html_context.update(
@@ -50,6 +53,7 @@ def setup(app):
     app.add_config_value("copybutton_prompt_is_regexp", False, "html")
     app.add_config_value("copybutton_only_copy_prompt_lines", True, "html")
     app.add_config_value("copybutton_remove_prompts", True, "html")
+    app.add_config_value("copybutton_copy_empty_lines", False, "html")
     app.add_config_value("copybutton_image_path", "copy-button.svg", "html")
     app.add_config_value("copybutton_selector", "div.highlight pre", "html")
 

--- a/sphinx_copybutton/__init__.py
+++ b/sphinx_copybutton/__init__.py
@@ -53,7 +53,7 @@ def setup(app):
     app.add_config_value("copybutton_prompt_is_regexp", False, "html")
     app.add_config_value("copybutton_only_copy_prompt_lines", True, "html")
     app.add_config_value("copybutton_remove_prompts", True, "html")
-    app.add_config_value("copybutton_copy_empty_lines", False, "html")
+    app.add_config_value("copybutton_copy_empty_lines", True, "html")
     app.add_config_value("copybutton_image_path", "copy-button.svg", "html")
     app.add_config_value("copybutton_selector", "div.highlight pre", "html")
 

--- a/sphinx_copybutton/_static/copybutton.js_t
+++ b/sphinx_copybutton/_static/copybutton.js_t
@@ -91,7 +91,7 @@ const addCopyButtonToCodeCells = () => {
 
 var copyTargetText = (trigger) => {
   var target = document.querySelector(trigger.attributes['data-clipboard-target'].value);
-  return formatCopyText(target.innerText, {{ "{!r}".format(copybutton_prompt_text) }}, {{ copybutton_prompt_is_regexp | lower }}, {{ copybutton_only_copy_prompt_lines | lower }},  {{ copybutton_remove_prompts | lower }})
+  return formatCopyText(target.innerText, {{ "{!r}".format(copybutton_prompt_text) }}, {{ copybutton_prompt_is_regexp | lower }}, {{ copybutton_only_copy_prompt_lines | lower }}, {{ copybutton_remove_prompts | lower }}, {{ copybutton_copy_empty_lines | lower }})
 }
 
   // Initialize with a callback so we can modify the text before copy

--- a/sphinx_copybutton/_static/copybutton_funcs.js
+++ b/sphinx_copybutton/_static/copybutton_funcs.js
@@ -4,7 +4,7 @@ function escapeRegExp(string) {
 
 // Callback when a copy button is clicked. Will be passed the node that was clicked
 // should then grab the text and replace pieces of text that shouldn't be used in output
-export function formatCopyText(textContent, copybuttonPromptText, isRegexp = false, onlyCopyPromptLines = true, removePrompts = true) {
+export function formatCopyText(textContent, copybuttonPromptText, isRegexp = false, onlyCopyPromptLines = true, removePrompts = true, copyEmptyLines = false) {
 
     var regexp;
     var match;
@@ -27,10 +27,10 @@ export function formatCopyText(textContent, copybuttonPromptText, isRegexp = fal
             } else {
                 outputLines.push(line)
             }
-        } else {
-            if (!onlyCopyPromptLines) {
-                outputLines.push(line)
-            }
+        } else if (!onlyCopyPromptLines) {
+            outputLines.push(line)
+        } else if (copyEmptyLines && line.trim() === '') {
+            outputLines.push(line)
         }
     }
 

--- a/sphinx_copybutton/_static/copybutton_funcs.js
+++ b/sphinx_copybutton/_static/copybutton_funcs.js
@@ -4,7 +4,7 @@ function escapeRegExp(string) {
 
 // Callback when a copy button is clicked. Will be passed the node that was clicked
 // should then grab the text and replace pieces of text that shouldn't be used in output
-export function formatCopyText(textContent, copybuttonPromptText, isRegexp = false, onlyCopyPromptLines = true, removePrompts = true, copyEmptyLines = false) {
+export function formatCopyText(textContent, copybuttonPromptText, isRegexp = false, onlyCopyPromptLines = true, removePrompts = true, copyEmptyLines = true) {
 
     var regexp;
     var match;

--- a/sphinx_copybutton/_static/test.js
+++ b/sphinx_copybutton/_static/test.js
@@ -30,7 +30,7 @@ output
 		isRegexp: false,
 		onlyCopyPromptLines: true,
 		removePrompts: true,
-		expected: 'first\nsecond'
+		expected: '\nfirst\nsecond'
 	},
 	{
 		description: 'with non-regexp console prompt',
@@ -42,7 +42,7 @@ $ second`,
 		isRegexp: false,
 		onlyCopyPromptLines: true,
 		removePrompts: true,
-		expected: 'first\nsecond'
+		expected: '\nfirst\nsecond'
 	},
 	{
 		description: 'with non-regexp prompt, keep prompt',
@@ -54,7 +54,7 @@ output
 		isRegexp: false,
 		onlyCopyPromptLines: true,
 		removePrompts: false,
-		expected: '>>> first\n>>> second'
+		expected: '\n>>> first\n>>> second'
 	},
 	{
 		description: 'with non-regexp prompt, keep lines',
@@ -90,7 +90,7 @@ output
 		isRegexp: true,
 		onlyCopyPromptLines: true,
 		removePrompts: true,
-		expected: 'first\nsecond'
+		expected: '\nfirst\nsecond'
 	},
 	{
 		description: 'with regexp python prompt and empty lines',
@@ -107,6 +107,20 @@ output
 		expected: '\nfirst\n\nsecond'
 	},
 	{
+		description: 'with regexp python prompt and empty lines, ignore empty lines',
+		text: `
+>>> first
+output
+
+>>> second`,
+		prompt: '>>> ',
+		isRegexp: true,
+		onlyCopyPromptLines: true,
+		removePrompts: true,
+		copyEmptyLines: false,
+		expected: 'first\nsecond'
+	},
+	{
 		description: 'with regexp console prompt',
 		text: `
 $ first
@@ -116,7 +130,7 @@ $ second`,
 		isRegexp: true,
 		onlyCopyPromptLines: true,
 		removePrompts: true,
-		expected: 'first\nsecond'
+		expected: '\nfirst\nsecond'
 	},
 	{
 		description: 'with ipython prompt (old and new style) regexp',
@@ -130,7 +144,7 @@ In [3]: jupyter`,
 		isRegexp: true,
 		onlyCopyPromptLines: true,
 		removePrompts: true,
-		expected: 'first\ncontinuation\nsecond\njupyter',
+		expected: '\nfirst\ncontinuation\nsecond\njupyter',
 	},
 	{
 		description: 'with ipython prompt (old and new style) regexp, keep prompts',
@@ -144,7 +158,7 @@ In [3]: jupyter`,
 		isRegexp: true,
 		onlyCopyPromptLines: true,
 		removePrompts: false,
-		expected: '[1]: first\n...: continuation\n[2]: second\nIn [3]: jupyter',
+		expected: '\n[1]: first\n...: continuation\n[2]: second\nIn [3]: jupyter',
 	},
 	{
 	/* The following is included to demonstrate an example of a false positive regex test.
@@ -161,7 +175,7 @@ output
 		isRegexp: true,
 		onlyCopyPromptLines: true,
 		removePrompts: true,
-		expected: 'first\ncontinuation\nsecond'
+		expected: '\nfirst\ncontinuation\nsecond'
 	}
 ]
 

--- a/sphinx_copybutton/_static/test.js
+++ b/sphinx_copybutton/_static/test.js
@@ -93,6 +93,20 @@ output
 		expected: 'first\nsecond'
 	},
 	{
+		description: 'with regexp python prompt and empty lines',
+		text: `
+>>> first
+output
+
+>>> second`,
+		prompt: '>>> ',
+		isRegexp: true,
+		onlyCopyPromptLines: true,
+		removePrompts: true,
+		copyEmptyLines: true,
+		expected: '\nfirst\n\nsecond'
+	},
+	{
 		description: 'with regexp console prompt',
 		text: `
 $ first
@@ -153,7 +167,7 @@ output
 
 parameters.forEach((p) => {
 	test(p.description, t => {
-		const text = formatCopyText(p.text, p.prompt, p.isRegexp, p.onlyCopyPromptLines, p.removePrompts);
+		const text = formatCopyText(p.text, p.prompt, p.isRegexp, p.onlyCopyPromptLines, p.removePrompts, p.copyEmptyLines);
 		t.is(text, p.expected)
 	});
 })


### PR DESCRIPTION
Dear Chris,

this is an attempt to resolve #84 reported by @chrisjsewell. Let me know what you think about it.

With kind regards,
Andreas.

---

Edit: As per discussion at https://github.com/executablebooks/sphinx-copybutton/pull/127#issuecomment-850317061 ff., this patch, now, both:
- brings in the baseline feature (f18bd05)
- _and_ makes "copying empty lines" the default behavior (da08b04).
