### PR TITLE
🐛 FIX: Fix edge-case when page is '#'

### DIFF
--- a/sphinx_copybutton/_static/copybutton.js_t
+++ b/sphinx_copybutton/_static/copybutton.js_t
@@ -44,7 +44,7 @@ if( document.documentElement.lang !== undefined
   locale = document.documentElement.lang
 }
 
-let doc_url_root = `${DOCUMENTATION_OPTIONS.URL_ROOT}`;
+let doc_url_root = DOCUMENTATION_OPTIONS.URL_ROOT;
 if (doc_url_root == '#') {
     doc_url_root = '';
 }

--- a/sphinx_copybutton/_static/copybutton.js_t
+++ b/sphinx_copybutton/_static/copybutton.js_t
@@ -44,7 +44,12 @@ if( document.documentElement.lang !== undefined
   locale = document.documentElement.lang
 }
 
-const path_static = `${DOCUMENTATION_OPTIONS.URL_ROOT}_static/`;
+let doc_url_root = `${DOCUMENTATION_OPTIONS.URL_ROOT}`;
+if (doc_url_root == '#') {
+    doc_url_root = '';
+}
+
+const path_static = `${doc_url_root}_static/`;
 
 /**
  * Set up copy/paste for code blocks


### PR DESCRIPTION
When building on Read the Docs, the parameter
DOCUMENTATION_OPTIONS.URL_ROOT can return '#' and that returns an
incorrect path to the svg icon for the copy button.

Closes: #121
