### PR TITLE
✨ ENH: Update icon to use GitHub style

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,6 +75,7 @@ pygments_style = "sphinx"
 html_theme = "sphinx_book_theme"
 # html_theme = "alabaster"
 # html_theme = "sphinx_rtd_theme"
+# html_theme = "furo"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/setup.py
+++ b/setup.py
@@ -61,5 +61,10 @@ setup(
     install_requires=["sphinx>=1.8"],
     extras_require={
         "code_style": ["pre-commit==2.12.1"],
+        "rtd": [
+            "sphinx",
+            "ipython",
+            "sphinx-book-theme",
+        ],
     },
 )

--- a/sphinx_copybutton/_static/check-solid.svg
+++ b/sphinx_copybutton/_static/check-solid.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-check" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-check" width="44" height="44" viewBox="0 0 24 24" stroke-width="2" stroke="#22863a" fill="none" stroke-linecap="round" stroke-linejoin="round">
   <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
   <path d="M5 12l5 5l10 -10" />
 </svg>

--- a/sphinx_copybutton/_static/copy-button.svg
+++ b/sphinx_copybutton/_static/copy-button.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="#607D8B" fill="none" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-clipboard" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#2c3e50" fill="none" stroke-linecap="round" stroke-linejoin="round">
   <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-  <rect x="8" y="8" width="12" height="12" rx="2" />
-  <path d="M16 8v-2a2 2 0 0 0 -2 -2h-8a2 2 0 0 0 -2 2v8a2 2 0 0 0 2 2h2" />
+  <path d="M9 5h-2a2 2 0 0 0 -2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-12a2 2 0 0 0 -2 -2h-2" />
+  <rect x="9" y="3" width="6" height="4" rx="2" />
 </svg>

--- a/sphinx_copybutton/_static/copybutton.css
+++ b/sphinx_copybutton/_static/copybutton.css
@@ -14,7 +14,7 @@ button.copybtn {
     outline: none;
     border-radius: 0.4em;
     border: #e1e1e1 1px solid;
-    background-color: rgb(233, 233, 233);
+    background-color: rgb(245, 245, 245);
 }
 
 button.copybtn.success {
@@ -35,7 +35,7 @@ div.highlight  {
 }
 
 .highlight button.copybtn:hover {
-    background-color: rgb(223, 223, 223);
+    background-color: rgb(235, 235, 235);
 }
 
 .highlight button.copybtn:active {

--- a/sphinx_copybutton/_static/copybutton.css
+++ b/sphinx_copybutton/_static/copybutton.css
@@ -4,8 +4,8 @@ button.copybtn {
     display: flex;
     top: .3em;
     right: .5em;
-    width: 1.7rem;
-    height: 1.7rem;
+    width: 1.7em;
+    height: 1.7em;
 	opacity: 0;
     transition: opacity 0.3s, border .3s, background-color .3s;
     user-select: none;
@@ -59,9 +59,9 @@ div.highlight  {
     visibility: hidden;
     position: absolute;
     content: attr(data-tooltip);
-    padding: .2rem;
-    font-size: .8rem;
-    left: -.2rem;
+    padding: .2em;
+    font-size: .8em;
+    left: -.2em;
     background: grey;
     color: white;
     white-space: nowrap;

--- a/sphinx_copybutton/_static/copybutton.css
+++ b/sphinx_copybutton/_static/copybutton.css
@@ -1,20 +1,29 @@
 /* Copy buttons */
 button.copybtn {
     position: absolute;
+    display: flex;
     top: .3em;
     right: .5em;
     width: 1.7rem;
     height: 1.7rem;
 	opacity: 0;
-    transition: opacity 0.3s, border .3s;
+    transition: opacity 0.3s, border .3s, background-color .3s;
     user-select: none;
     padding: 0;
     border: none;
     outline: none;
+    border-radius: 0.4em;
+    border: #e1e1e1 1px solid;
+    background-color: rgb(233, 233, 233);
+}
+
+button.copybtn.success {
+    border-color: #22863a;
 }
 
 button.copybtn img {
     width: 100%;
+    padding: .2em;
 }
 
 div.highlight  {
@@ -22,11 +31,15 @@ div.highlight  {
 }
 
 .highlight:hover button.copybtn {
-	opacity: .7;
+	opacity: 1;
 }
 
 .highlight button.copybtn:hover {
-	opacity: 1;
+    background-color: rgb(223, 223, 223);
+}
+
+.highlight button.copybtn:active {
+    background-color: rgb(187, 187, 187);
 }
 
 /**
@@ -46,11 +59,10 @@ div.highlight  {
     visibility: hidden;
     position: absolute;
     content: attr(data-tooltip);
-    padding: 2px;
-    top: 0;
-    left: -.2em;
+    padding: .2rem;
+    font-size: .8rem;
+    left: -.2rem;
     background: grey;
-    font-size: 1rem;
     color: white;
     white-space: nowrap;
     z-index: 2;

--- a/sphinx_copybutton/_static/copybutton.js_t
+++ b/sphinx_copybutton/_static/copybutton.js_t
@@ -81,7 +81,9 @@ const clearSelection = () => {
 // Changes tooltip text for two seconds, then changes it back
 const temporarilyChangeTooltip = (el, oldText, newText) => {
   el.setAttribute('data-tooltip', newText)
+  el.classList.add('success')
   setTimeout(() => el.setAttribute('data-tooltip', oldText), 2000)
+  setTimeout(() => el.classList.remove('success'), 2000)
 }
 
 // Changes the copy button icon for two seconds, then changes it back
@@ -104,10 +106,9 @@ const addCopyButtonToCodeCells = () => {
   codeCells.forEach((codeCell, index) => {
     const id = codeCellId(index)
     codeCell.setAttribute('id', id)
-    const pre_bg = getComputedStyle(codeCell).backgroundColor;
 
     const clipboardButton = id =>
-    `<button class="copybtn o-tooltip--left" style="background-color: ${pre_bg}" data-tooltip="${messages[locale]['copy']}" data-clipboard-target="#${id}">
+    `<button class="copybtn o-tooltip--left" data-tooltip="${messages[locale]['copy']}" data-clipboard-target="#${id}">
       <img src="${path_static}{{ copybutton_image_path }}" alt="${messages[locale]['copy_to_clipboard']}">
     </button>`
     codeCell.insertAdjacentHTML('afterend', clipboardButton(id))

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,42 @@
+# To use tox, see https://tox.readthedocs.io
+# Simply pip or conda install tox
+# If you use conda, you may also want to install tox-conda
+# then run `tox` or `tox -- {pytest args}`
+# To run in parallel using `tox -p` (this does not appear to work for this repo)
+
+# To rebuild the tox environment, for example when dependencies change, use
+# `tox -r`
+
+# Note: if the following error is encountered: `ImportError while loading conftest`
+# then then deleting compiled files has been found to fix it: `find . -name \*.pyc -delete`
+
+[tox]
+envlist = py37-sphinx3
+
+[testenv]
+# only recreate the environment when we use `tox -r`
+recreate = false
+
+[testenv:docs-build]
+description = Build the documentation and launch browser
+extras =
+    rtd
+commands =
+    sphinx-build \
+        -n -b {posargs:html} docs/ docs/_build/{posargs:html}
+
+[testenv:docs-live]
+description = Build the documentation and launch browser
+deps =
+    sphinx-autobuild
+    sphinx-rtd-theme
+    alabaster
+    furo
+extras =
+    rtd
+commands =
+    sphinx-autobuild \
+        --re-ignore _build/.* \
+        --watch sphinx_copybutton \
+        --port 0 --open-browser \
+        -n -b {posargs:html} docs/ docs/_build/{posargs:html}


### PR DESCRIPTION
This is an update to the SVG icon + hovering behavior that we use. Now that GitHub has its own copy button auto-added, we might be able to reduce cognitive load on users by mimicking their UX. This PR is an attempt at that!

It also adds in a background color (neutral gray) rather than trying to inherit the background from its parent element, which I think was introducing some variability.

Curious what @pradyunsg thinks 

GitHub behavior:

![2021-06-22_12-02-58](https://user-images.githubusercontent.com/1839645/122984416-d6884a80-d351-11eb-95e5-64dbf2f2c321.gif)

This PR behavior:

![2021-06-27_10-54-56](https://user-images.githubusercontent.com/1839645/123554734-46be1400-d736-11eb-806a-76aa846def18.gif)


It is hard to get the behavior totally consistent across themes etc, and I had a hard time getting the heights to quite line up, so please make suggestions if you think there are improvements to make there (or elsewhere).