### PR TITLE
RLS: v0.5.1 and move `Publish to PyPI` action to dedicated file

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -66,27 +66,3 @@ jobs:
       run: |
         cd docs
         make html
-
-  publish:
-
-    name: Publish to PyPI
-    needs: [pre-commit, docs]
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.x"
-      - name: Build package
-        run: |
-          pip install build
-          git submodule update --init
-          python -m build
-      - name: Publish
-        uses: pypa/gh-action-pypi-publish@v1.5.1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+# This will run every time a tag is created and pushed to the repository.
+# It calls our tests workflow via a `workflow_call`, and if tests pass
+# then it triggers our upload to PyPI for a new release.
+name: Publish to PyPI
+on:
+  release:
+    types: ["published"]
+
+jobs:
+  tests:
+    uses: ./.github/workflows/integration.yml
+  publish:
+    name: publish
+    needs: [tests] # require tests to pass before deploy runs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - name: Build package
+        run: |
+          pip install build
+          git submodule update --init
+          python -m build
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@v1.5.1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.5.1 - 2022-11-15
+
+([full changelog](https://github.com/executablebooks/sphinx-copybutton/compare/v0.5.0...e529aa0c7c0bf6ad880904f7a8876f33040e5c09))
+
+- ENH: Unselectable text is now also not highlighted when you manually highlight a code cell. Exclude unselectable text from being copied (update) [#178](https://github.com/executablebooks/sphinx-copybutton/pull/178) ([@rkdarst](https://github.com/rkdarst))
+- ENH: After copying, the copybutton will disappear _before_ the icon changes back if you are no longer hovering on the code cell. FIX: Make copybutton remain for a second during success [#176](https://github.com/executablebooks/sphinx-copybutton/pull/176) ([@choldgraf](https://github.com/choldgraf))
+- MAINT: Add support for Python 3.10 [#174](https://github.com/executablebooks/sphinx-copybutton/pull/174) ([@hugovk](https://github.com/hugovk))
+
 ## 0.5.0 - 2022-02-05
 
 ([full changelog](https://github.com/executablebooks/sphinx-copybutton/compare/v0.4.0...915aa4cf0b06f7b781bc4edfc204c62f2ce7cdb6))

--- a/sphinx_copybutton/__init__.py
+++ b/sphinx_copybutton/__init__.py
@@ -2,7 +2,7 @@
 from pathlib import Path
 from sphinx.util import logging
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Cutting a release to bring in the recent improvements that @rkdarst made.

I've also moved our `Publish to PyPI` action to a dedicated workflow, so that it no longer shows up as a `didn't run` job in our CI/CD and will reduce the noise in merging PRs.