### PR TITLE
Demonstration of selecting only commands using Pygments-only

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,8 +111,8 @@ html_title = "Sphinx Copybutton"
 myst_enable_extensions = ["colon_fence"]
 
 # CopyButton configuration
-#copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
-#copybutton_prompt_is_regexp = True
+# copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+# copybutton_prompt_is_regexp = True
 copybutton_line_continuation_character = "\\"
 copybutton_here_doc_delimiter = "EOT"
 copybutton_selector = "div:not(.no-copybutton) > div.highlight > pre"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,11 +111,13 @@ html_title = "Sphinx Copybutton"
 myst_enable_extensions = ["colon_fence"]
 
 # CopyButton configuration
-copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
-copybutton_prompt_is_regexp = True
+#copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+#copybutton_prompt_is_regexp = True
 copybutton_line_continuation_character = "\\"
 copybutton_here_doc_delimiter = "EOT"
 copybutton_selector = "div:not(.no-copybutton) > div.highlight > pre"
+copybutton_exclude = ".linenos, .gp, .go"
+copybutton_copy_empty_lines = False
 
 # Switches for testing but shouldn't be activated in the live docs
 # copybutton_only_copy_prompt_lines = False

--- a/docs/use.md
+++ b/docs/use.md
@@ -88,7 +88,7 @@ An example usage would be the `ipython`-directive:
 ```restructuredtext
 ``ipython`` and ``qtconsole`` style:
 
-.. code-block:: ipython
+.. code-block:: ipythonconsole
 
    In [1]: first
       ...: continuation
@@ -97,7 +97,7 @@ An example usage would be the `ipython`-directive:
 
 ``jupyter`` style:
 
-.. code-block:: ipython
+.. code-block:: ipythonconsole
 
    In [1]: first
          : continuation
@@ -107,7 +107,7 @@ An example usage would be the `ipython`-directive:
 
 `ipython` and `qtconsole` style:
 
-```ipython
+```ipythonconsole
 In [1]: first
    ...: continuation
 output
@@ -116,7 +116,7 @@ In [2]: second
 
 `jupyter` style:
 
-```ipython
+```ipythonconsole
 In [1]: first
       : continuation
 output
@@ -175,7 +175,7 @@ See below for how to control this.
 
 Sometimes you may wish to copy a code block like this one:
 
-```bash
+```console
 $ datalad download-url http://www.tldp.org/LDP/Bash-Beginners-Guide/Bash-Beginners-Guide.pdf \
 --dataset . \
 -m "add beginners guide on bash" \
@@ -205,7 +205,7 @@ rules.
 in which line breaks and other whitespace (including indentation) is preserved.
 For example:
 
-```bash
+```console
 $ cat << EOT > notes.txt
    This is an example sentence.
        Put some indentation on this line.

--- a/sphinx_copybutton/_static/copybutton_funcs.js
+++ b/sphinx_copybutton/_static/copybutton_funcs.js
@@ -42,7 +42,9 @@ export function formatCopyText(textContent, copybuttonPromptText, isRegexp = fal
     const lineGotPrompt = [];
     for (const line of textContent.split('\n')) {
         match = line.match(regexp)
-        if (match || gotLineCont || gotHereDoc) {
+        if (!copyEmptyLines && line.trim() === '') {
+            // do nothing
+	} else if (match || gotLineCont || gotHereDoc) {
             promptFound = regexp.test(line)
             lineGotPrompt.push(promptFound)
             if (removePrompts && promptFound) {
@@ -55,9 +57,7 @@ export function formatCopyText(textContent, copybuttonPromptText, isRegexp = fal
                 gotHereDoc = !gotHereDoc
         } else if (!onlyCopyPromptLines) {
             outputLines.push(line)
-        } else if (copyEmptyLines && line.trim() === '') {
-            outputLines.push(line)
-        }
+	}
     }
 
     // If no lines with the prompt were found then just use original lines


### PR DESCRIPTION
- Remove the prompt regexes and set `copybutton_exclude='.linenos,
  .gp, .go'`.  We get a similar behaviour as before, but with no
  custom configuration and would (in theory) work with any
  Pygments-supported language.

- This is a demonstration of solution (b) in #185.  We don't define
  prompt or output regexes, but let Pygments lex it and give it css
  classes.  Here, we exclude Generic.Prompt and Generic.Output
  classes.

- The formatCopyText function had to be adjusted, since the "remove
  blank lines" only worked if the prompt detection was on.  This
  re-ordering enables it all the time, which isn't great, since it can
  remove other meaningful blank lines.  It needs to be thought out
  better.

- The IPython and bash lexers are changed to their respective console
  lexers.

- Here documents don't seem to work.  Pygments could be improved to
  support this better.

- Further discussion is in #185.  This should not be merged.
