### PR TITLE
BUG: Don't exclude `.gp` class by default

### DIFF
--- a/sphinx_copybutton/__init__.py
+++ b/sphinx_copybutton/__init__.py
@@ -81,7 +81,7 @@ def setup(app):
     app.add_config_value("copybutton_here_doc_delimiter", "", "html")
     app.add_config_value("copybutton_image_svg", "", "html")
     app.add_config_value("copybutton_selector", "div.highlight pre", "html")
-    app.add_config_value("copybutton_exclude", ".linenos, .gp", "html")
+    app.add_config_value("copybutton_exclude", ".linenos", "html")
 
     # DEPRECATE THIS AFTER THE NEXT RELEASE
     app.add_config_value("copybutton_image_path", "", "html")


### PR DESCRIPTION
- Immediate fix to backwards compatibility of #185.
- I'm not implying I wouldn't want to change the default later.
