### PR TITLE
Change URL to official Tabler Icons website

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -104,4 +104,4 @@ changelog
 ## Inspiration
 
 The UI and design elements of `sphinx-copybutton` are heavily inspired by [GitHub's design choices](https://primer.style).
-The icon we use is from [Tabler's icons set](https://tablericons.com/).
+The icon we use is from [Tabler Icons set](https://tabler.io/icons/).


### PR DESCRIPTION
Hi, I hope you’re doing well!

I wanted to kindly ask if you could update the link to Tabler Icons to the correct URL: https://tabler.io/icons.

The current site, tablericons. com, isn’t affiliated with the Tabler Icons project. The person behind it is misleading users by claiming to be the author of the library. You can verify the official project and its details here: https://github.com/tabler/tabler-icons.

Thanks so much for your understanding and for supporting accurate representation of the Tabler project!

Best regards
Bartek, co-owner of https://github.com/tabler
